### PR TITLE
Modify GitHub actions workflow to reduce redundant runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,10 @@
 name: ci
 on:
   push:
-  pull_request:
+    branches:
+      - master
+  pull_request: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This commit modifies the CI workflow to only run when pushed to master or on
pull requests. This avoids the CI running twice when a pull request is opened/synced.

Signed-off-by: David Bond <davidsbond93@gmail.com>