### PR TITLE
Upgrade go version & action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,10 @@
 version: 2
 updates:
-  - package-ecosystem: "gomod"
-    directory: "/"
+  - package-ecosystem: gomod
+    directory: /
     schedule:
-      interval: "daily"
+      interval: daily
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,23 +23,8 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
-
-      - name: Get cache paths
-        id: cache
-        run: |
-          echo "::set-output name=build::$(go env GOCACHE)"
-          echo "::set-output name=module::$(go env GOMODCACHE)"
-
-      - name: Set up cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ steps.cache.outputs.build }}
-            ${{ steps.cache.outputs.module }}
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          go-version-file: go.mod
+          cache: true
 
       - name: Run tests
         run: go test -race ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,41 +7,26 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.18.x
-
       - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
-      - name: Get cache paths
-        id: cache
-        run: |
-          echo "::set-output name=build::$(go env GOCACHE)"
-          echo "::set-output name=module::$(go env GOMODCACHE)"
-
-      - name: Set up cache
-        uses: actions/cache@v3
+      - name: Install Go
+        uses: actions/setup-go@v3
         with:
-          path: |
-            ${{ steps.cache.outputs.build }}
-            ${{ steps.cache.outputs.module }}
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          go-version-file: go.mod
+          cache: true
 
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v3
+        uses: crazy-max/ghaction-import-gpg@v5
         with:
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
           args: release --rm-dist

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/davidsbond/vault-plugin-tailscale
 
-go 1.18
+go 1.19
 
 require (
 	github.com/hashicorp/go-hclog v1.3.0


### PR DESCRIPTION
This commit modifies the go module to require go 1.19, it also upgrades any github
actions to their latest versions.

Signed-off-by: David Bond <davidsbond93@gmail.com>