### PR TITLE
Add support for ephemeral keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $ vault write tailscale/config tailnet=$TAILNET api_key=$API_KEY
 Success! Data written to: tailscale/config
 ```
 
-2. Generate keys using the Vault CLI.
+3. Generate keys using the Vault CLI.
 
 ```shell
 $ vault read tailscale/key
@@ -53,4 +53,32 @@ id           kMxzN47CNTRL
 key          secret-key-data
 reusable     false
 tags         <nil>
+```
+
+### Key Options
+
+The following key/value pairs can be added to the end of the `vault read` command to configure key properties:
+
+#### Tags
+
+Tags to apply to the device that uses the authentication key
+
+```
+vault read tailscale/key tags=something:somewhere
+```
+
+#### Preauthorized
+
+If true, machines added to the tailnet with this key will not required authorization
+
+```
+vault read tailscale/key preauthorized=true
+```
+
+#### Ephemeral
+
+If true, nodes created with this key will be removed after a period of inactivity or when they disconnect from the Tailnet
+
+```
+vault read tailscale/key ephemeral=true
 ```

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -26,6 +26,9 @@ func TestBackend_GenerateKey(t *testing.T) {
 		"preauthorized": {
 			Type: framework.TypeBool,
 		},
+		"ephemeral": {
+			Type: framework.TypeBool,
+		},
 	}
 
 	tt := []struct {
@@ -75,10 +78,11 @@ func TestBackend_GenerateKey(t *testing.T) {
 			response, err := b.GenerateKey(ctx, tc.Request, tc.Data)
 
 			if tc.ExpectsError {
-				assert.Error(t, response.Error())
+				assert.Error(t, err)
 				return
 			}
 
+			assert.NoError(t, err)
 			assert.EqualValues(t, tc.Expected, response.Data)
 		})
 	}
@@ -125,13 +129,13 @@ func TestBackend_ReadConfiguration(t *testing.T) {
 			}
 
 			response, err := b.ReadConfiguration(ctx, tc.Request, tc.Data)
-			assert.NoError(t, err)
 
 			if tc.ExpectsError {
-				assert.Error(t, response.Error())
+				assert.Error(t, err)
 				return
 			}
 
+			assert.NoError(t, err)
 			assert.EqualValues(t, tc.Expected, response.Data)
 		})
 	}
@@ -202,14 +206,14 @@ func TestBackend_UpdateConfiguration(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.Name, func(t *testing.T) {
-			response, err := b.UpdateConfiguration(ctx, tc.Request, tc.Data)
-			assert.NoError(t, err)
+			_, err := b.UpdateConfiguration(ctx, tc.Request, tc.Data)
 
 			if tc.ExpectsError {
-				assert.Error(t, response.Error())
+				assert.Error(t, err)
 				return
 			}
 
+			assert.NoError(t, err)
 			assert.EqualValues(t, tc.Expected, getConfig(t, ctx, tc.Request))
 		})
 	}


### PR DESCRIPTION
This commit adds a new option when reading tailnet keys that allows for the creation of ephemeral keys. It also standardises the error handling across the backend and adds additional documentation for how to customise key options when reading.

Closes #50

Signed-off-by: David Bond <davidsbond93@gmail.com>